### PR TITLE
Reversed meaning on RCC CR register bit meanings

### DIFF
--- a/peripherals/rcc/rcc_f0.yaml
+++ b/peripherals/rcc/rcc_f0.yaml
@@ -1,8 +1,8 @@
 RCC:
   CR:
     "*ON":
-      On: [0, "Clock disabled"]
-      Off: [1, "Clock enabled"]
+      Off: [0, "Clock disabled"]
+      On: [1, "Clock enabled"]
     PLLRDY:
       _read:
         Unlocked: [0, "PLL unlocked"]

--- a/peripherals/rcc/rcc_f002a.yaml
+++ b/peripherals/rcc/rcc_f002a.yaml
@@ -1,8 +1,8 @@
 RCC:
   CR:
     "*ON":
-      On: [0, "Clock disabled"]
-      Off: [1, "Clock enabled"]
+      Off: [0, "Clock disabled"]
+      On: [1, "Clock enabled"]
     HSEBYP:
       NotBypassed: [0, "HSE oscillator not bypassed"]
       Bypassed: [1, "HSE oscillator bypassed"]

--- a/peripherals/rcc/rcc_f003.yaml
+++ b/peripherals/rcc/rcc_f003.yaml
@@ -1,8 +1,8 @@
 RCC:
   CR:
     "*ON":
-      On: [0, "Clock disabled"]
-      Off: [1, "Clock enabled"]
+      Off: [0, "Clock disabled"]
+      On: [1, "Clock enabled"]
     HSEBYP:
       NotBypassed: [0, "HSE oscillator not bypassed"]
       Bypassed: [1, "HSE oscillator bypassed"]


### PR DESCRIPTION
I was testing a simple led flashing program on my dev board, and could not get the clock subsystem to use the external oscillator. Determined that it was due to a bug in the peripheral crate.

Peripheral RCC register CR HSEON and HSION had On/Off bit enums backwards. Reversed them. I only have the PY32F030 device, but it appears that the same problem is in some of the other devices also.